### PR TITLE
Allow company logo path to have a space in it

### DIFF
--- a/templates/invoice.jade
+++ b/templates/invoice.jade
@@ -15,7 +15,7 @@ html.no-js
                 | }
             if invoice.company_logo
                 | .logo {
-                |     background-image: url(#{invoice.company_logo});
+                |     background-image: url("#{invoice.company_logo}");
                 |     width: 300px;
                 |     background-repeat:  no-repeat;
                 |     background-size: 300px;


### PR DESCRIPTION
I work a bunch in bash for windows. So my path actually has spaces in it. Quoting it allows this to not break.

Ex: "/mnt/c/Users/Gavin Mogan/Documents/git/billing/lib/img/sauce_logo.png"